### PR TITLE
Possible expand_shards documentation typo

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -212,7 +212,7 @@ aces-cli cohort_name="foo" cohort_dir="bar/" data.standard=meds data.path="baz.p
 A MEDS dataset can have multiple shards, each stored as a `.parquet` file containing subsets of the full dataset. We can make use of Hydra's launchers and multi-run (`-m`) capabilities to start an extraction job for each shard (`data=sharded`), either in series or in parallel (e.g., using `joblib`, or `submitit` for Slurm). To load data with multiple shards, a data root needs to be provided, along with an expression containing a comma-delimited list of files for each shard. We provide a function `expand_shards` to do this, which accepts a sequence representing `<shards_location>/<number_of_shards>`. It also accepts a file directory, where all `.parquet` files in its directory and subdirectories will be included.
 
 ```bash
-aces-cli cohort_name="foo" cohort_dir="bar/" data.standard=meds data=sharded data.root="baz/" "data.shard=$(expand_shards qux/#)" -m
+aces-cli cohort_name="foo" cohort_dir="bar/" data.standard=meds data=sharded data.root="baz/" "data.shard=$(expand_shards baz/)" -m
 ```
 
 ### ESGPT


### PR DESCRIPTION
expand_shards should take in the same input as data.root in the documentation right?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated command-line usage example for the `aces-cli` tool to reflect the correct directory for loading MEDS dataset shards.
	- Clarified the argument for the `data.shard` parameter to ensure users reference the correct location for their dataset shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->