### PR TITLE
Upgraded numpy

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.imgconverter",
-    "sphinxcontrib.collections",
+    "sphinx_collections",
     "sphinx_subfigure",
     "sphinx_immaterial",
     "myst_parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "polars ~= 1.30.0",
-    "numpy < 1.29.0",
+    "numpy",
     "bigtree == 0.18.*",
     "ruamel.yaml == 0.18.*",
     "hydra-core ~= 1.3.2",


### PR DESCRIPTION
Allows numpy to advance to version 2+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed NumPy dependency to allow newer NumPy releases (upper bound removed).
* **Documentation**
  * Updated documentation build configuration to use the renamed Sphinx extension, ensuring correct extension loading and related directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->