### PR TITLE
Relax safe dependency floors; add minimum-versions CI lane (refs #201)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,3 +39,29 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  run_tests_min_deps:
+    # Verifies that the lower bounds declared in pyproject.toml are actually installable
+    # and pass the test suite. Keeps us honest about the floor advertised in metadata.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install at minimum-direct versions
+        run: |
+          uv sync --extra tests --resolution lowest-direct
+
+      - name: Run tests
+        run: |
+          uv run --extra tests --resolution lowest-direct pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,23 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    # Kept tight for now; see https://github.com/justin13601/ACES/issues/201 for the plan
+    # to relax polars and meds once doctests are decoupled from polars' expr printing.
     "polars ~= 1.30.0",
-    "numpy",
-    "bigtree == 0.18.*",
-    "ruamel.yaml == 0.18.*",
-    "hydra-core ~= 1.3.2",
-    "pytimeparse == 1.1.*",
-    "networkx == 3.3.*",
-    "pyarrow",
     "meds ~= 0.4.0",
+    # Numeric / arrow: loose floors only. numpy 1.26 is the oldest version that ships
+    # wheels for py 3.12+ (earlier versions need distutils at build time).
+    "numpy >= 1.26",
+    "pyarrow >= 15",
+    # Config / CLI: hydra's CLI surface has been stable across 1.3.x. Keep 1.3.x lower
+    # bound (resolver bugs in 1.3.0 were fixed in 1.3.2) but allow any future patch.
+    "hydra-core >= 1.3.2, < 2",
+    # Graph / tree / YAML / time: only narrow, long-stable API surface is used. Floors
+    # picked so that every symbol actually referenced in src/aces is present.
+    "networkx >= 3.1, < 4",       # write_network_text was added in 3.1
+    "bigtree >= 0.14, < 1",       # Node, preorder_iter, print_tree have been stable since 0.14
+    "ruamel.yaml >= 0.17, < 1",   # YAML(typ="safe", pure=True) API unchanged since 0.17
+    "pytimeparse >= 1.1.8, < 2",  # effectively only 1.1.8 works (earlier releases lack top-level parse)
 ]
 
 [tool.setuptools]
@@ -43,8 +51,13 @@ expand_shards = "aces.expand_shards:main"
 
 [project.optional-dependencies]
 dev = ["pre-commit<4", "ruff"]
-tests = ["pytest", "pytest-cov", "pytest-subtests", "hypothesis"]
-profiling = ["psutil"]
+tests = [
+    "pytest >= 7.4",
+    "pytest-cov >= 4",
+    "pytest-subtests >= 0.11",
+    "hypothesis >= 6.100",
+]
+profiling = ["psutil >= 5.9"]
 
 [project.urls]
 Homepage = "https://github.com/justin13601/ACES"


### PR DESCRIPTION
## Summary

First pass on the dependency relaxation plan laid out in #201. Loosens the *safe* pins (graph / tree / YAML / time / numeric-array libraries) and adds a CI lane that verifies the advertised floors are actually installable and green.

### What changed in `pyproject.toml`

| Before | After | Why |
|---|---|---|
| `numpy` (unpinned) | `numpy >= 1.26` | 1.26 is the first release that installs on py 3.12 without `distutils` at build time. |
| `pyarrow` (unpinned) | `pyarrow >= 15` | Covers `meds ~= 0.4.0`. |
| `hydra-core ~= 1.3.2` | `hydra-core >= 1.3.2, < 2` | No ceiling beyond the still-unreleased 2.0. |
| `networkx == 3.3.*` | `networkx >= 3.1, < 4` | `write_network_text` landed in 3.1; ACES uses no 3.3-specific APIs. |
| `bigtree == 0.18.*` | `bigtree >= 0.14, < 1` | Only `Node`, `preorder_iter`, `print_tree` are used; stable since 0.14. |
| `ruamel.yaml == 0.18.*` | `ruamel.yaml >= 0.17, < 1` | `YAML(typ="safe", pure=True)` API has been stable since 0.17. |
| `pytimeparse == 1.1.*` | `pytimeparse >= 1.1.8, < 2` | 1.1.8 is the only release where `from pytimeparse import parse` works. |
| `tests = [... unpinned]` | Floors added (`pytest >= 7.4`, `hypothesis >= 6.100`, etc.) | Required for `uv --resolution lowest-direct` to not pull pre-historic releases. |

**Not touched in this PR** (tracked in #201 for follow-ups):
- `polars ~= 1.30.0` — doctests embed polars' expression-repr format, which drifts across versions. Needs a separate PR that rewrites the affected doctests before polars can safely float.
- `meds ~= 0.4.0` — label schema and column names differ between 0.3.x and 0.4.x; needs fixture work.

### New CI job: `run_tests_min_deps`

Installs via `uv sync --extra tests --resolution lowest-direct` and runs `pytest`. This means the floors advertised in `pyproject.toml` are continuously checked; if someone loosens a bound without the code actually supporting it, this job goes red.

### Verification

Locally on Python 3.12:

- `uv sync --extra tests --resolution lowest-direct && pytest` → **39/39 pass**
- `uv sync --extra tests && pytest` (default highest resolution) → **39/39 pass**

## Test plan

- [x] All tests pass locally on `--resolution lowest-direct`
- [x] All tests pass locally on default (highest) resolution
- [ ] `run_tests_min_deps` CI lane green
- [ ] `run_tests_ubuntu` (pip-based, py 3.10) CI lane green

Refs #201
