### PR TITLE
Relax polars and meds ceilings for downstream co-install flexibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,14 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    # Kept tight for now; see https://github.com/justin13601/ACES/issues/201 for the plan
-    # to relax polars and meds once doctests are decoupled from polars' expr printing.
-    "polars ~= 1.30.0",
-    "meds ~= 0.4.0",
+    # Polars / MEDS: ceilings relaxed so downstream MEDS tooling (MEDS-Transforms,
+    # MEDS-Extract, MEDS_trajectory_evaluation, etc.) can co-install without being
+    # pinned to the exact 1.30 / 0.4 release. Doctests are still written against
+    # polars 1.30's expression repr, so when a newer polars changes that repr the
+    # doctests will need updating — tracked in
+    # https://github.com/justin13601/ACES/issues/201.
+    "polars >= 1.30, < 2",
+    "meds >= 0.4, < 0.6",
     # Numeric / arrow: loose floors only. numpy 1.26 is the oldest version that ships
     # wheels for py 3.12+ (earlier versions need distutils at build time).
     "numpy >= 1.26",

--- a/uv.lock
+++ b/uv.lock
@@ -211,10 +211,10 @@ dev = [
 requires-dist = [
     { name = "bigtree", specifier = ">=0.14,<1" },
     { name = "hydra-core", specifier = ">=1.3.2,<2" },
-    { name = "meds", specifier = "~=0.4.0" },
+    { name = "meds", specifier = ">=0.4,<0.6" },
     { name = "networkx", specifier = ">=3.1,<4" },
     { name = "numpy", specifier = ">=1.26" },
-    { name = "polars", specifier = "~=1.30.0" },
+    { name = "polars", specifier = ">=1.30,<2" },
     { name = "psutil", marker = "extra == 'profiling'", specifier = ">=5.9" },
     { name = "pyarrow", specifier = ">=15" },
     { name = "pytimeparse", specifier = ">=1.1.8,<2" },
@@ -576,16 +576,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.30.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/b6/8dbdf626c0705a57f052708c9fc0860ffc2aa97955930d5faaf6a66fcfd3/polars-1.30.0.tar.gz", hash = "sha256:dfe94ae84a5efd9ba74e616e3e125b24ca155494a931890a8f17480737c4db45", size = 4668318, upload-time = "2025-05-21T13:33:24.175Z" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/1b/eea7d6fe6daafc1d784cc0f76c729b28051837ccb2d51ae64a0a3f798142/polars-1.40.0.tar.gz", hash = "sha256:711dd50dcbc35ba42a2625fcadc2a1349e2e9abf48e35631bdabafb90d89874b", size = 732943, upload-time = "2026-04-18T05:25:26.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/48/e9b2cb379abcc9f7aff2e701098fcdb9fe6d85dc4ad4cec7b35d39c70951/polars-1.30.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4c33bc97c29b7112f0e689a2f8a33143973a3ff466c70b25c7fd1880225de6dd", size = 35704342, upload-time = "2025-05-21T13:32:22.996Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ca/f545f61282f75eea4dfde4db2944963dcd59abd50c20e33a1c894da44dad/polars-1.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e3d05914c364b8e39a5b10dcf97e84d76e516b3b1693880bf189a93aab3ca00d", size = 32459857, upload-time = "2025-05-21T13:32:27.728Z" },
-    { url = "https://files.pythonhosted.org/packages/76/20/e018cd87d7cb6f8684355f31f4e193222455a6e8f7b942f4a2934f5969c7/polars-1.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a52af3862082b868c1febeae650af8ae8a2105d2cb28f0449179a7b44f54ccf", size = 36267243, upload-time = "2025-05-21T13:32:31.796Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e7/b88b973021be07b13d91b9301cc14392c994225ef5107a32a8ffd3fd6424/polars-1.30.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:ffb3ef133454275d4254442257c5f71dd6e393ce365c97997dadeb6fa9d6d4b5", size = 33416871, upload-time = "2025-05-21T13:32:35.077Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7c/d46d4381adeac537b8520b653dc30cb8b7edbf59883d71fbb989e9005de1/polars-1.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:c26b633a9bd530c5fc09d317fca3bb3e16c772bd7df7549a9d8ec1934773cc5d", size = 36363630, upload-time = "2025-05-21T13:32:38.286Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/b5/5056d0c12aadb57390d0627492bef8b1abf3549474abb9ae0fd4e2bfa885/polars-1.30.0-cp39-abi3-win_arm64.whl", hash = "sha256:476f1bde65bc7b4d9f80af370645c2981b5798d67c151055e58534e89e96f2a8", size = 32643590, upload-time = "2025-05-21T13:32:42.107Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ad/d5ed79269b7fe59a3dbbfbdbecbe1e59a0b56e38d36491e57d2bfb5846c1/polars-1.40.0-py3-none-any.whl", hash = "sha256:60b1d677ca363e2fc6fdea8c3d16c0653fd52cc37f0249e0f29d9536d5aa45ef", size = 828012, upload-time = "2026-04-18T05:23:39.055Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/b2/eae6c1b3d16c7a64ff382f557985ff939cce13455e8c9d056ab8e1e0fc87/polars_runtime_32-1.40.0.tar.gz", hash = "sha256:e31bff8bd37492c714e155e2e1429ac2d9ddf2dd6ec6474cc1cc70ac0b2bd6af", size = 2935285, upload-time = "2026-04-18T05:25:28.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e4/2325689d2af4f9e70699ff98e8a2543707bebc34af78a5fe0e654107d9ed/polars_runtime_32-1.40.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cab3ac7ff5bc9e0f4b3b146015569e9417cf0eaff8d3fb71004d73d67b6f09c7", size = 52092528, upload-time = "2026-04-18T05:23:42.341Z" },
+    { url = "https://files.pythonhosted.org/packages/19/a6/82157b19c5c40b2c1ed0493b87b9eaf9b4863cdedca5575ee083488b45ba/polars_runtime_32-1.40.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d29624c75c4049253300786d00882fce620b3677ce495ebc4199292de8c2ba02", size = 46365073, upload-time = "2026-04-18T05:23:46.7Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/5c4f1f2545f56c664cc57bbdd1aa66fcfcb129aa137ed72cc81d58eb480f/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a034dc0d8481fc1ca0456ab33e98e53a4c6d6cc6a2edb36246cc81c936b925dc", size = 50250561, upload-time = "2026-04-18T05:23:51.316Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/51/cb5eb75394f39c0ec14fddcc9b11adb707e1f28224a552ecbfa72d39b61b/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70e78c2f13a54a9d92ae30d2625bda759173cc4867ad6a39f85f140058d899c6", size = 56243695, upload-time = "2026-04-18T05:23:55.932Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3a/be1437c0fbecbb07d81b151456089c3cf054eea5a791f849ed39b67611ca/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1843272c0ef49f4a07435888f0059eca08ec16ab9880219c457195a081df0281", size = 50427843, upload-time = "2026-04-18T05:24:00.159Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/ea6449a2161816a13ed1d8aa02177d5a0594e011f0df5ddd2fad8e5bf20e/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:081237dba07f15d61fc151825f203165480e9503ebe72a474a8c99aa78021962", size = 54153077, upload-time = "2026-04-18T05:24:05.066Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1a/0b239138afe8b80a1a0b4c95db3884e6afbbe82ec3318918ab03bc57f231/polars_runtime_32-1.40.0-cp310-abi3-win_amd64.whl", hash = "sha256:a916040e0b7f461ce987e4551fed9eea5914b4fbb5af907b1d9e80db71fadeb5", size = 51822748, upload-time = "2026-04-18T05:24:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ce/c16ef8fd3030b7342032b040fab21a42f6fee57e47ee7f41e2f1a1e36f01/polars_runtime_32-1.40.0-cp310-abi3-win_arm64.whl", hash = "sha256:719c64eecde24a95aa3599eb9c8efc98c1499bab7ef9c01cbbe8939cd583e654", size = 45819617, upload-time = "2026-04-18T05:24:13.214Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Relaxes the `polars` and `meds` ceilings so that downstream MEDS-ecosystem libraries (MEDS_trajectory_evaluation, MEDS-Extract, MEDS-Transforms, meds-torch-data, etc.) can co-install with ACES without being pinned onto the exact `polars==1.30.x` / `meds==0.4.x` line.

| Dep | Was | Now |
|---|---|---|
| `polars` | `~= 1.30.0` | `>= 1.30, < 2` |
| `meds` | `~= 0.4.0` | `>= 0.4, < 0.6` |

No other constraints change. Specifically, **no floors are raised on any other dependency** — nothing in `src/aces` requires a newer numpy / pyarrow / networkx / bigtree / ruamel.yaml than the floor established in #202, so widening the upper end is all that's needed.

## Rebased / scope change

This PR was originally titled "Bump dependency floors toward current major releases" and proposed a more aggressive set of changes (`numpy>=2.0`, `pyarrow>=20`, etc.). That scope was pulled back per reviewer feedback — bumping floors that the code doesn't actually need narrows the install window without adding value and blocks downstream co-installs ([concrete case: MEDS_trajectory_evaluation#28](https://github.com/mmcdermott/MEDS_trajectory_evaluation/pull/28)). Dev-tooling pins and mdformat/pre-commit hooks have landed separately in #206.

Branch has been force-pushed; the remaining delta against `main` is just this one ceiling-loosening commit plus its `uv.lock` update.

## Follow-ups (separate PRs, tracked in #201)

- Decouple doctests from polars' internal expression repr so the polars constraint can loosen further.
- Evaluate whether `meds >= 0.4, < 0.6` → `>= 0.4, < 0.7` or wider is realistic once meds 0.5 ships and we understand the schema delta.

## Test plan

- [x] `uv run pytest` — 39/39 pass on default resolution
- [x] `uv run --group dev --resolution lowest-direct pytest` — 39/39 pass
- [ ] CI green on this PR

Refs #201
