### PR TITLE
Fix Tests workflow: bump codecov-action v4 -> v5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
           pytest -v --cov=src
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

Tests on main went red right after #202 merged, but not because of a test regression — all 39 tests pass with 97% coverage. The failure is entirely in the Codecov upload step:

\`\`\`
codecov/codecov-action@v4.0.1
→ Could not pull latest version information: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
→ (falls back to gpg-verified uploader download)
→ Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:161:15)
    ...
\`\`\`

Codecov's uploader-version endpoint is now returning an HTML page instead of JSON, and the v4 action's gpg-verification fallback crashes with \`write EPIPE\` from the \`gpg\` subprocess. v5 of the action uses the current codecov CLI and doesn't rely on that path.

The step runs on every push to main as well as PRs, so v4 has effectively been broken for anyone pushing lately — it's not specific to #202.

## Test plan

- [x] Tests themselves passed on main (39/39, 97% coverage) — only the upload step needs fixing
- [ ] CI green on this PR

Fixes the "Tests" run at https://github.com/justin13601/ACES/actions/runs/24742396346.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test coverage upload tool in the CI/CD pipeline to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->