### PR TITLE
Refresh GH Actions, pre-commit hooks, and dev deps; pin everything

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,12 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6.2.0
       with:
         python-version: "${{ inputs.python-version }}"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"

--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -24,7 +24,7 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
 
       - name: List all changed files
         run: echo '${{ steps.file_changes.outputs.all_changed_files }}'

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -24,7 +24,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   github-release:
     name: >-
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
           uv run pytest -v --cov=src
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -41,14 +41,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install at minimum-direct versions
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -20,7 +20,7 @@ repos:
 
   # python code formatting, linting, and import sorting using ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.11
     hooks:
       # Run the formatter
       - id: ruff-format
@@ -28,45 +28,51 @@ repos:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
 
-  # python docstring formatting
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+  # python docstring formatting.
+  # Held at v1.7.7: v1.7.5 still ships a `docformatter-venv` hook with the
+  # removed `language: python_venv`, which pre-commit 4 rejects. v1.7.8 regressed
+  # on multi-line string literals used as positional args (e.g. fixture YAML
+  # passed to parse_shards_yaml in tests), rewriting them into broken syntax.
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=110, --wrap-descriptions=110]
 
-  # yaml formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  # yaml formatting (pre-commit/mirrors-prettier is archived; using the community fork)
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
     hooks:
       - id: prettier
         types: [yaml]
 
   # shell scripts linter
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 
-  # md formatting
+  # md formatting (all nested plugins pinned to avoid float drift in CI).
+  # Held at mdformat 0.7.x because mdformat-tables 1.0.0 still pins `mdformat<0.8`;
+  # revisit once the plugin ecosystem catches up with mdformat 1.x.
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-config
-          - mdformat-myst
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat-frontmatter==2.0.10
+          - mdformat-config==0.2.1
+          - mdformat-myst==0.3.0
+          - mdformat-toc==0.5.0
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -75,7 +81,7 @@ repos:
 
   # jupyter notebook cell output clearing
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,12 @@ profiling = ["psutil >= 5.9"]
 
 [dependency-groups]
 dev = [
-    "pre-commit<4",
-    "ruff",
-    "pytest >= 7.4",
-    "pytest-cov >= 4",
-    "pytest-subtests >= 0.11",
-    "hypothesis >= 6.100",
+    "pre-commit >= 4.5, < 5",
+    "ruff >= 0.15, < 1",
+    "pytest >= 8.4, < 10",
+    "pytest-cov >= 7, < 8",
+    "pytest-subtests >= 0.15, < 1",
+    "hypothesis >= 6.150, < 7",
 ]
 
 [project.urls]

--- a/tests/test_expand_shards.py
+++ b/tests/test_expand_shards.py
@@ -7,7 +7,7 @@ from .utils import run_command
 
 
 def test_e2e():
-    es_stderr, es_stdout = run_command("expand_shards train/3 tuning/1", {}, "expand_shards")
+    _es_stderr, es_stdout = run_command("expand_shards train/3 tuning/1", {}, "expand_shards")
     assert es_stdout == "train/0,train/1,train/2,tuning/0\n", (
         f"Expected 'train/0,train/1,train/2,tuning/0' but got '{es_stdout}'"
     )
@@ -21,6 +21,6 @@ def test_e2e():
             shard_fp.mkdir(parents=True)
             shard_fp.touch()
 
-        es_stderr, es_stdout = run_command(f"expand_shards {data_dir}", {}, "expand_shards")
+        _es_stderr, es_stdout = run_command(f"expand_shards {data_dir}", {}, "expand_shards")
         got_shards = es_stdout.strip().split(",")
         assert sorted(got_shards) == sorted(want_shards), f"Expected {want_shards} but got {got_shards}"

--- a/tests/test_help_message.py
+++ b/tests/test_help_message.py
@@ -5,11 +5,11 @@ from .utils import run_command
 
 def test_e2e():
     # Running with the empty directory
-    help_stderr, help_stdout = run_command("aces-cli", {}, "help", expected_returncode=1)
+    _help_stderr, help_stdout = run_command("aces-cli", {}, "help", expected_returncode=1)
     assert "Usage: aces-cli [OPTIONS]" in help_stdout, (
         f"Expected help message not found in stdout. Got {help_stdout}"
     )
 
     # Running with the empty directory
-    help_stderr, help_stdout = run_command("aces-cli -h", {}, "help", expected_returncode=0)
+    _help_stderr, help_stdout = run_command("aces-cli -h", {}, "help", expected_returncode=0)
     assert "== aces-cli ==" in help_stdout, f"Expected help message not found in stdout. Got {help_stdout}"

--- a/uv.lock
+++ b/uv.lock
@@ -224,12 +224,12 @@ provides-extras = ["profiling"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "hypothesis", specifier = ">=6.100" },
-    { name = "pre-commit", specifier = "<4" },
-    { name = "pytest", specifier = ">=7.4" },
-    { name = "pytest-cov", specifier = ">=4" },
-    { name = "pytest-subtests", specifier = ">=0.11" },
-    { name = "ruff" },
+    { name = "hypothesis", specifier = ">=6.150,<7" },
+    { name = "pre-commit", specifier = ">=4.5,<5" },
+    { name = "pytest", specifier = ">=8.4,<10" },
+    { name = "pytest-cov", specifier = ">=7,<8" },
+    { name = "pytest-subtests", specifier = ">=0.15,<1" },
+    { name = "ruff", specifier = ">=0.15,<1" },
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "3.8.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -599,9 +599,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/10/97ee2fa54dff1e9da9badbc5e35d0bbaef0776271ea5907eccf64140f72f/pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af", size = 177815, upload-time = "2024-07-28T19:59:01.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f", size = 204643, upload-time = "2024-07-28T19:58:59.335Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refreshes every pinned external tool to its current stable release and makes the pinning deterministic — including the previously-unpinned `additional_dependencies` list of mdformat plugins, which is the usual culprit for "my CI passed yesterday and fails today" flakiness.

### GitHub Actions (now pinned to exact tag, not floating major)

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6.0.2` |
| `actions/setup-python` | `@v5` | `@v6.2.0` |
| `astral-sh/setup-uv` | `@v6` | `@v8.1.0` |
| `actions/upload-artifact` | `@v4` | `@v7.0.1` |
| `actions/download-artifact` | `@v4` | `@v8.0.1` |
| `pypa/gh-action-pypi-publish` | `@release/v1` (branch!) | `@v1.14.0` |
| `sigstore/gh-action-sigstore-python` | `@v3.0.0` | `@v3.3.0` |
| `tj-actions/changed-files` | `@v46.0.5` | `@v47.0.6` |
| `codecov/codecov-action` | `@v5` | `@v6.0.0` |

### Pre-commit hooks

| Hook | Was | Now | Notes |
|---|---|---|---|
| `pre-commit/pre-commit-hooks` | v5.0.0 | v6.0.0 | |
| `astral-sh/ruff-pre-commit` | v0.11.7 | v0.15.11 | aligns with ruff on PyPI |
| docformatter | `myint/docformatter@v1.7.5` | `PyCQA/docformatter@v1.7.7` | v1.7.5 fails pre-commit 4 validation; v1.7.8 mis-reformats multi-line string args |
| prettier mirror | `pre-commit/mirrors-prettier@v4.0.0-alpha.8` | `rbubley/mirrors-prettier@v3.8.3` | the `pre-commit/` mirror is archived; rbubley's is the community replacement and tracks stable Prettier |
| `shellcheck-py/shellcheck-py` | v0.10.0.1 | v0.11.0.1 | |
| `executablebooks/mdformat` | 0.7.22 | 0.7.22 | **intentionally held** — `mdformat-tables 1.0.0` still pins `mdformat<0.8`, so the ecosystem hasn't caught up with mdformat 1.x |
| `codespell-project/codespell` | v2.4.1 | v2.4.2 | |
| `kynan/nbstripout` | 0.8.1 | 0.9.1 | |
| `nbQA-dev/nbQA` | 1.9.1 | 1.9.1 | already current |

### mdformat nested plugin pins

Previously floated on each plugin's latest-compatible resolve. Now pinned exactly, which is the fix for the "CI went red because a plugin released a new version overnight" failure mode:

```
mdformat-ruff==0.1.3
mdformat-gfm==1.0.0
mdformat-gfm-alerts==2.0.0
mdformat-tables==1.0.0
mdformat-frontmatter==2.0.10
mdformat-config==0.2.1
mdformat-myst==0.3.0
mdformat-toc==0.5.0
```

### Dev-group dependencies (now bounded on both ends)

| Dep | Was | Now |
|---|---|---|
| `pre-commit` | `<4` | `>= 4.5, < 5` |
| `ruff` | unpinned | `>= 0.15, < 1` |
| `pytest` | `>= 7.4` | `>= 8.4, < 10` |
| `pytest-cov` | `>= 4` | `>= 7, < 8` |
| `pytest-subtests` | `>= 0.11` | `>= 0.15, < 1` |
| `hypothesis` | `>= 6.100` | `>= 6.150, < 7` |

### Minor code fixes

The new ruff version introduces RUF059 (unused unpacked variable). Two test files had `stderr, stdout = ...` patterns where `stderr` was ignored — prefixed with `_` to silence the rule without losing the shape of the assignment.

### Local verification (py 3.12)

- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run pytest` — **39 / 39 pass**
- [x] `uv run --group dev --resolution lowest-direct pytest` — **39 / 39 pass**

## Test plan

- [x] pre-commit clean locally
- [x] pytest green locally (both resolutions)
- [ ] CI green on this PR (tests 3.10–3.13, min-deps, code-quality, build, docs)
