### PR TITLE
Exclude MEDS_BIRTH rows from predicate evaluation and _ANY_EVENT (closes #168)

### DIFF
--- a/src/aces/predicates.py
+++ b/src/aces/predicates.py
@@ -3,6 +3,7 @@
 import logging
 from pathlib import Path
 
+import meds
 import polars as pl
 from omegaconf import DictConfig
 from polars.exceptions import ColumnNotFoundError
@@ -269,6 +270,13 @@ def generate_plain_predicates_from_meds(
 
     logger.info("Loading MEDS data...")
     data = pl.read_parquet(data_path, use_pyarrow=True).rename({"time": "timestamp"})
+
+    # Drop MEDS birth rows before predicate evaluation. The birth code is a
+    # quasi-static demographic marker anchored at the patient's birth timestamp;
+    # it shouldn't count toward predicate matches or the implicit _ANY_EVENT
+    # column. Static rows (null timestamp) are already excluded; this extends
+    # the same treatment to MEDS_BIRTH. See issue #168.
+    data = data.filter(pl.col("code") != meds.birth_code)
 
     # generate plain predicate columns
     logger.info("Generating plain predicate columns...")

--- a/src/aces/predicates.py
+++ b/src/aces/predicates.py
@@ -271,6 +271,12 @@ def generate_plain_predicates_from_meds(
     logger.info("Loading MEDS data...")
     data = pl.read_parquet(data_path, use_pyarrow=True).rename({"time": "timestamp"})
 
+    # Cast `code` to Utf8 once up front. Older MEDS schemas sometimes emitted `code` as
+    # a categorical / enum dtype, and both the birth-row filter below and the per-predicate
+    # expression loop assume a string column. (Previously the cast was repeated once per
+    # predicate inside the loop; hoisting it avoids that redundant work.)
+    data = data.with_columns(pl.col("code").cast(pl.Utf8))
+
     # Drop MEDS birth rows before predicate evaluation. The birth code is a
     # quasi-static demographic marker anchored at the patient's birth timestamp;
     # it shouldn't count toward predicate matches or the implicit _ANY_EVENT
@@ -281,7 +287,6 @@ def generate_plain_predicates_from_meds(
     # generate plain predicate columns
     logger.info("Generating plain predicate columns...")
     for name, plain_predicate in predicates.items():
-        data = data.with_columns(data["code"].cast(pl.Utf8).alias("code"))  # may remove after MEDS v0.3
         data = data.with_columns(plain_predicate.MEDS_eval_expr().cast(PRED_CNT_TYPE).alias(name))
         logger.info(f"Added predicate column '{name}'.")
 

--- a/tests/test_any_event_excludes_birth.py
+++ b/tests/test_any_event_excludes_birth.py
@@ -1,0 +1,45 @@
+"""Regression test for issue #168: `_ANY_EVENT` must not include MEDS_BIRTH rows."""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import meds
+import polars as pl
+
+from aces.predicates import generate_plain_predicates_from_meds
+
+
+def test_meds_birth_rows_do_not_contribute_to_any_event():
+    """A MEDS birth row should not inflate downstream `_ANY_EVENT` counts.
+
+    Historically `_ANY_EVENT` was defined as "every (subject_id, timestamp) with a non-null
+    timestamp", which incorrectly swept in `meds.birth_code` rows (the birth row is a quasi-
+    static demographic marker anchored at the patient's birth time, not a clinical event).
+    See https://github.com/justin13601/ACES/issues/168.
+    """
+    data = pl.DataFrame(
+        {
+            "subject_id": [1, 1, 1, 2],
+            "time": [
+                datetime(1980, 1, 1),  # birth
+                datetime(2020, 1, 1),  # clinical event
+                datetime(2020, 1, 2),  # clinical event
+                datetime(1990, 6, 1),  # birth-only patient
+            ],
+            "code": [meds.birth_code, "LAB//HR", "LAB//HR", meds.birth_code],
+            "numeric_value": [None, 72.0, 80.0, None],
+        }
+    )
+
+    with tempfile.TemporaryDirectory() as d:
+        data_path = Path(d) / "data.parquet"
+        data.write_parquet(data_path)
+        got = generate_plain_predicates_from_meds(data_path, predicates={})
+
+    # Subject 1 should have 2 rows (the two clinical events), not 3 (which would include birth).
+    # Subject 2 had only a birth row, so it should drop out entirely.
+    got = got.sort("subject_id", "timestamp")
+    assert got.height == 2, f"Expected 2 rows post-birth-filter; got {got.height}:\n{got}"
+    assert got["subject_id"].to_list() == [1, 1]
+    assert got["timestamp"].to_list() == [datetime(2020, 1, 1), datetime(2020, 1, 2)]

--- a/tests/test_other_meds.py
+++ b/tests/test_other_meds.py
@@ -358,7 +358,6 @@ WANT_SHARDS = {
         """
   "0": |-2
     subject_id,prediction_time,boolean_value,integer_value,float_value,categorical_value
-    1,01/15/2020 15:14,0,,,
     1,01/19/2022 04:46,0,,,
     1,01/25/2022 08:11,1,,,
 

--- a/tests/test_override_meds.py
+++ b/tests/test_override_meds.py
@@ -377,7 +377,6 @@ WANT_SHARDS = {
         """
   "0": |-2
     subject_id,prediction_time,boolean_value,integer_value,float_value,categorical_value
-    1,01/15/2020 15:14,0,,,
     1,01/19/2022 04:46,0,,,
 
   "1": |-2


### PR DESCRIPTION
## Summary

Closes #168.

`_ANY_EVENT` is currently defined as "every (subject_id, timestamp) with a non-null timestamp" (see `src/aces/predicates.py`). That check swept in the MEDS birth row (`code == meds.birth_code`): the birth row is a quasi-static demographic marker anchored at the patient's birth timestamp — semantically static, but carrying a timestamp for MEDS schema reasons — and it was counting as a clinical event.

That silently inflated every `_ANY_EVENT: (N, None)` data-sufficiency gate by 1 for any patient whose record reaches back to birth. A task like "input window must contain at least 5 events" was implicitly admitting patients with only 4 real clinical events.

## Fix

Filter `code == meds.birth_code` rows in `generate_plain_predicates_from_meds` before predicate evaluation and `(subject_id, timestamp)` aggregation. This naturally cascades:

- Birth rows no longer contribute to `_ANY_EVENT`.
- Birth rows no longer contribute to user-defined plain predicates either — which matches MEDS's own treatment of the birth row as metadata.

ESGPT and direct standards are untouched; they have no equivalent birth concept.

## Design alternatives considered

1. **Filter birth rows in the MEDS loader (chosen here).** Minimum code change (~3 lines). Anyone previously matching `code: MEDS_BIRTH` as a plain predicate now gets zero matches.
2. **Carry a `_has_non_birth_at_ts` marker column from the MEDS loader through to `_ANY_EVENT` computation and drop it before returning.** Preserves the ability to match `code: MEDS_BIRTH` as a plain predicate. ~10 lines, touches two functions, leaks an internal column across the loader boundary.
3. **Introduce a new special predicate `_BIRTH_EVENT` and redefine `_ANY_EVENT` as "non-null timestamp AND NOT `_BIRTH_EVENT`".** Cleanest semantic model but adds API surface and documentation requirements — overkill for a bugfix.

If anyone's use case needs option 2 (matching birth as a plain predicate), easy to pivot.

## Regression risks

- **Users matching `code: MEDS_BIRTH` as a plain predicate** will now see zero matches. Arguably a correction (birth should flow through static demographics), but worth calling out in release notes.
- **Test expectations tied to pre-fix counts:** `tests/test_other_meds.py` and `tests/test_override_meds.py` both include birth rows in their fixture data and use `_ANY_EVENT: (5, None)` gates. Subject 1 in `inhospital_mortality` had a 01/14/2020 admission trigger that was only passing the gate because the birth row inflated the count to 5. Post-fix it correctly drops out. Expected outputs updated accordingly; no other test cases cross the boundary.
- **ESGPT / direct standards** — untouched.

## Test plan

- [x] New regression test in `tests/test_any_event_excludes_birth.py`: birth-only patients drop entirely; patients with birth + clinical events keep only the clinical timestamps.
- [x] `uv run pytest` — 40/40 pass locally (39 pre-existing + 1 new).
- [x] `uv run pre-commit run --all-files` — clean.
- [ ] CI green.
- [ ] Copilot review addressed.

## Files changed

- `src/aces/predicates.py` — 3-line filter + import `meds`; docstring/comment.
- `tests/test_any_event_excludes_birth.py` — new regression test.
- `tests/test_other_meds.py` / `tests/test_override_meds.py` — drop the one now-correctly-excluded row in the `inhospital_mortality/0.parquet` expected output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Birth records are no longer treated as clinical events in event-based analyses.
  - Event-derived predictions now exclude records associated only with a birth event, preventing spurious labels from appearing in results.
  - Timestamp handling has been improved for compatible text-based data inputs.

- **Tests**
  - Added regression coverage to verify birth-event exclusion and updated expected prediction outputs accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->