### PR TITLE
Bundle sample_configs and configuration/algorithm docs as package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 include-package-data = true
 
 [tool.setuptools.package-data]
-your_package = ["*.pyi", "py.typed"]
+aces = ["sample_configs/*.yaml", "_docs/*.md"]
 
 [tool.setuptools_scm]
 

--- a/src/aces/_docs/algorithm.md
+++ b/src/aces/_docs/algorithm.md
@@ -1,0 +1,1 @@
+../../../docs/source/algorithm.md

--- a/src/aces/_docs/configuration.md
+++ b/src/aces/_docs/configuration.md
@@ -1,0 +1,1 @@
+../../../docs/source/configuration.md

--- a/src/aces/sample_configs/abnormal_lab.yaml
+++ b/src/aces/sample_configs/abnormal_lab.yaml
@@ -1,0 +1,1 @@
+../../../sample_configs/abnormal_lab.yaml

--- a/src/aces/sample_configs/imminent_mortality.yaml
+++ b/src/aces/sample_configs/imminent_mortality.yaml
@@ -1,0 +1,1 @@
+../../../sample_configs/imminent_mortality.yaml

--- a/src/aces/sample_configs/inhospital_mortality.yaml
+++ b/src/aces/sample_configs/inhospital_mortality.yaml
@@ -1,0 +1,1 @@
+../../../sample_configs/inhospital_mortality.yaml

--- a/src/aces/sample_configs/intervention_weaning.yaml
+++ b/src/aces/sample_configs/intervention_weaning.yaml
@@ -1,0 +1,1 @@
+../../../sample_configs/intervention_weaning.yaml

--- a/src/aces/sample_configs/long_term_recurrence.yaml
+++ b/src/aces/sample_configs/long_term_recurrence.yaml
@@ -1,0 +1,1 @@
+../../../sample_configs/long_term_recurrence.yaml

--- a/src/aces/sample_configs/readmission_risk.yaml
+++ b/src/aces/sample_configs/readmission_risk.yaml
@@ -1,0 +1,1 @@
+../../../sample_configs/readmission_risk.yaml


### PR DESCRIPTION
## Summary

Make `sample_configs/*.yaml` and `docs/source/{configuration,algorithm}.md` accessible via `importlib.resources` after `pip install es-aces`. Today they live outside `src/aces/` and are not shipped in the wheel.

## Motivation

Downstream tools using ACES programmatically need access to these files at runtime:

- The configuration / algorithm docs describe the ACES YAML grammar — useful as context for LLM-based tools that generate ACES configs.
- The sample configs are canonical templates for common tasks — useful as illustrative examples.

Today the only options are to clone the repo or vendor copies, both of which drift from the installed library version.

## Changes

- `pyproject.toml`: replace the placeholder `your_package = [...]` entry with a real one targeting the `aces` package.
- Symlinks inside `src/aces/` pointing at the existing files at their current locations:
  - `src/aces/sample_configs/`           → `../../sample_configs/`
  - `src/aces/_docs/configuration.md`    → `../../../docs/source/configuration.md`
  - `src/aces/_docs/algorithm.md`        → `../../../docs/source/algorithm.md`

No files are moved or copied. The originals stay where Sphinx, the README, and the CLI examples already reference them. \`setuptools\` follows the symlinks when building the wheel, so installed packages contain the actual file content.

## Verification

Built and installed locally into a fresh venv. After install:

\`\`\`python
from importlib.resources import files

# All six sample configs accessible
[p.name for p in files(\"aces\").joinpath(\"sample_configs\").iterdir()]
# ['abnormal_lab.yaml', 'imminent_mortality.yaml', 'inhospital_mortality.yaml',
#  'intervention_weaning.yaml', 'long_term_recurrence.yaml', 'readmission_risk.yaml']

# Tech spec readable
files(\"aces\").joinpath(\"_docs/configuration.md\").read_text()  # ~14k chars
files(\"aces\").joinpath(\"_docs/algorithm.md\").read_text()       # ~18k chars
\`\`\`

No behavioural code changes; existing tests should remain green.

## Alternatives considered

- **Move files into `src/aces/`**: cleanest end state but breaks the existing README, `docs/source/usage.md`, notebooks, `.gitignore`, and CLI examples that all reference `sample_configs/` at the repo root.
- **`MANIFEST.in`-only**: covers sdist but not wheel; downstream `importlib.resources` access wouldn't work after `pip install`.
- **Build-time copy hook**: portable but adds machinery to `pyproject.toml`. Happy to switch to this if symlinks are objectionable.

Open to a different mechanism if you'd prefer; the symlink approach was picked for minimum disruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include sample configuration files and documentation resources, providing easier access to reference materials and configuration examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/justin13601/ACES/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->